### PR TITLE
feat: Implement /hist_kline endpoint for historical K-line data

### DIFF
--- a/data_agent_service.py
+++ b/data_agent_service.py
@@ -1,0 +1,41 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# Mock data for demonstration purposes
+mock_kline_data = {
+    "600519.SH": [
+        {"date": "20230101", "open": 1700.00, "high": 1720.00, "low": 1690.00, "close": 1710.00, "volume": 10000},
+        {"date": "20230102", "open": 1710.00, "high": 1730.00, "low": 1700.00, "close": 1720.00, "volume": 12000},
+    ],
+    "000001.SZ": [
+        {"date": "20230101", "open": 12.00, "high": 12.20, "low": 11.90, "close": 12.10, "volume": 200000},
+        {"date": "20230102", "open": 12.10, "high": 12.30, "low": 12.00, "close": 12.20, "volume": 220000},
+    ]
+}
+
+@app.route('/hist_kline', methods=['GET'])
+def get_hist_kline():
+    symbol = request.args.get('symbol')
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+    frequency = request.args.get('frequency')
+
+    if not all([symbol, start_date, end_date, frequency]):
+        return jsonify({"error": "Missing required parameters"}), 400
+
+    # In a real application, you would fetch data from xtquant here
+    # For now, we return mock data
+    data = mock_kline_data.get(symbol, [])
+
+    # Filter data by date (simplified for mock data)
+    # A real implementation would handle date filtering more robustly
+    filtered_data = [
+        item for item in data
+        if start_date <= item['date'] <= end_date
+    ]
+
+    return jsonify(filtered_data)
+
+if __name__ == '__main__':
+    app.run(debug=True, port=5000)

--- a/test_data_agent_service.py
+++ b/test_data_agent_service.py
@@ -1,0 +1,62 @@
+import unittest
+import json
+from data_agent_service import app
+
+class TestDataAgentService(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+
+    def test_get_hist_kline_success(self):
+        params = {
+            "symbol": "600519.SH",
+            "start_date": "20230101",
+            "end_date": "20230102",  # Adjusted to match mock data range
+            "frequency": "1d"
+        }
+        response = self.app.get('/hist_kline', query_string=params)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode())
+        self.assertEqual(len(data), 2) # Expecting two data points for this symbol and date range
+        self.assertEqual(data[0]['date'], "20230101")
+        self.assertEqual(data[1]['date'], "20230102")
+
+    def test_get_hist_kline_missing_params(self):
+        params = {
+            "symbol": "600519.SH",
+            "start_date": "20230101"
+            # end_date and frequency are missing
+        }
+        response = self.app.get('/hist_kline', query_string=params)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data.decode())
+        self.assertIn("error", data)
+        self.assertEqual(data["error"], "Missing required parameters")
+
+    def test_get_hist_kline_symbol_not_found(self):
+        params = {
+            "symbol": "NONEXISTENT.SZ",
+            "start_date": "20230101",
+            "end_date": "20230102",
+            "frequency": "1d"
+        }
+        response = self.app.get('/hist_kline', query_string=params)
+        self.assertEqual(response.status_code, 200) # Endpoint currently returns empty list for unknown symbols
+        data = json.loads(response.data.decode())
+        self.assertEqual(len(data), 0)
+
+    def test_get_hist_kline_date_range_no_data(self):
+        params = {
+            "symbol": "600519.SH",
+            "start_date": "20240101", # Date range with no mock data
+            "end_date": "20240102",
+            "frequency": "1d"
+        }
+        response = self.app.get('/hist_kline', query_string=params)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode())
+        self.assertEqual(len(data), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a new Flask service `data_agent_service.py` with an endpoint `/hist_kline`. This endpoint simulates fetching historical K-line data based on symbol, start date, end date, and frequency.

Includes:
- Flask application setup.
- `/hist_kline` route with request parameter handling.
- Mock data implementation for initial testing.
- Unit tests for the new endpoint, covering various scenarios.
- Resolved Python environment issues by installing Python 3.11.0.